### PR TITLE
RBG 1110 fix ga tracking for external registration programs

### DIFF
--- a/programs-remote-listings/resources/frontend/rs_ga.js
+++ b/programs-remote-listings/resources/frontend/rs_ga.js
@@ -22,7 +22,8 @@ jQuery(document).ready(function($) {
     $(".rs-register-link a, .rs-show-register-link a").click(function(e){
         if (window.rs_ga_client_id && window.rs_ga_tracking_id){
             e.preventDefault();
-            location.href = $(this).prop("href") + "&ga-client-id=" + encodeURI(window.rs_ga_tracking_id)
+            var getVarSymbol = location.href.indexOf("?") >= 0 ? "&": "?";
+            location.href = $(this).prop("href") + getVarSymbol + "ga-client-id=" + encodeURI(window.rs_ga_tracking_id)
                 + encodeURI('~') + encodeURI(window.rs_ga_client_id);
         }
     });


### PR DESCRIPTION
This is an alternative fix that still allows tracking on the 3rd party external registration traffic
