### PR TITLE
clean css - complete css and rendering rework

### DIFF
--- a/programs-remote-listings/readme.txt
+++ b/programs-remote-listings/readme.txt
@@ -35,6 +35,9 @@ email support@retreat.guru or phone 1-888-881-0404 if you need help. Or send us 
 
 == Changelog ==
 
+= 2.3.0 =
+* fix layouts for desktop and mobile sites
+
 = 2.2.3 =
 * fix rs_register_button shortcode
 

--- a/programs-remote-listings/readme.txt
+++ b/programs-remote-listings/readme.txt
@@ -35,8 +35,8 @@ email support@retreat.guru or phone 1-888-881-0404 if you need help. Or send us 
 
 == Changelog ==
 
-= 2.3.0 =
-* fix layouts for desktop and mobile sites
+= 3.0.0 =
+* completely changed visual rendering to better fit most templates
 
 = 2.2.3 =
 * fix rs_register_button shortcode

--- a/programs-remote-listings/resources/frontend/rs.css
+++ b/programs-remote-listings/resources/frontend/rs.css
@@ -74,33 +74,29 @@
 
 /* Small list */
 
-.rs-small-list .rs-item .rs-item-title {
+.rs-list .rs-item .rs-item-title {
     margin-top: 0;
 }
 
-.rs-small-list .rs-item .rs-date {
-    font-weight: bold;
-}
-
-.rs-small-list .rs-item {
+.rs-list .rs-item {
     margin-bottom: 2em;
 }
 
-/* Single program */
+/* Teacher list */
 
-.rs-small-list.rs-teacher .rs-item .rs-photo {
+.rs-list.rs-teacher .rs-item .rs-photo {
     width: 150px;
     float: left;
     margin: 0 10px 0 0;
 }
 
-.rs-small-list.rs-teacher .rs-item .rs-content {
+.rs-list.rs-teacher .rs-item .rs-content {
     overflow: hidden;
 }
 
-/* Single teacher */
+/* Program list */
 
-.rs-small-list.rs-program .rs-item .rs-photo {
+.rs-list.rs-program .rs-item .rs-photo {
     width: 300px;
     float: right;
     margin: 0 0 0 20px;
@@ -118,8 +114,8 @@
     }
 
     .rs-single .rs-photo,
-    .rs-small-list.rs-program .rs-item .rs-photo,
-    .rs-small-list.rs-teacher .rs-item .rs-photo {
+    .rs-list.rs-program .rs-item .rs-photo,
+    .rs-list.rs-teacher .rs-item .rs-photo {
         width: 100%;
         float: none;
         margin: 20px 0;
@@ -129,11 +125,11 @@
         display: none;
     }
 
-    .rs-small-list .rs-item .rs-content {
+    .rs-list .rs-item .rs-content {
         overflow: visible;
     }
 
-    .rs-small-list .rs-item .rs-item-title {
+    .rs-list .rs-item .rs-item-title {
         margin-top: 10px;
     }
 }
@@ -146,3 +142,10 @@
     clear: both;
 }
 
+.rs-date {
+    font-weight: bold;
+}
+
+.rs-location {
+    font-weight: bold;
+}

--- a/programs-remote-listings/resources/frontend/rs.css
+++ b/programs-remote-listings/resources/frontend/rs.css
@@ -24,9 +24,18 @@
     margin: 10px 0;
 }
 
-/* Program Metabox */
+/* Single item page */
+
+.rs-single .rs-photo {
+    width: 300px;
+    float: left;
+    margin: 0 20px 0 0;
+}
+
+/* Program metabox */
 
 .rs-metabox {
+    float: right;
     width: 40%;
     border: 1px solid #ccc;
     padding: 10px;
@@ -65,34 +74,59 @@
 
 /* Small list */
 
-.rs-small-list .rs-item .rs-photo {
-    width: 150px;
+.rs-small-list .rs-item .rs-item-title {
+    margin-top: 0;
 }
 
-.rs-small-list .rs-item .rs-content {
+.rs-small-list .rs-item .rs-date {
+    font-weight: bold;
+}
+
+.rs-small-list .rs-item {
+    margin-bottom: 2em;
+}
+
+/* Single program */
+
+.rs-small-list.rs-teacher .rs-item .rs-photo {
+    width: 150px;
+    float: left;
+    margin: 0 10px 0 0;
+}
+
+.rs-small-list.rs-teacher .rs-item .rs-content {
     overflow: hidden;
 }
 
-.rs-small-list .rs-item .rs-item-title {
-    margin-top: 0;
+/* Single teacher */
+
+.rs-small-list.rs-program .rs-item .rs-photo {
+    width: 300px;
+    float: right;
+    margin: 0 0 0 20px;
 }
 
 /* Mobile overrides */
 
 @media screen and (max-width: 769px) {
     .rs-metabox {
+        float: none;
         border: none;
         padding: 0;
         margin: 0 0 20px 0;
         width: 100%;
     }
 
-    .rs-single.rs-program > .rs-action {
-        display: none;
+    .rs-single .rs-photo,
+    .rs-small-list.rs-program .rs-item .rs-photo,
+    .rs-small-list.rs-teacher .rs-item .rs-photo {
+        width: 100%;
+        float: none;
+        margin: 20px 0;
     }
 
-    .rs-small-list .rs-item .rs-photo {
-        width: 100%;
+    .rs-single.rs-program > .rs-action {
+        display: none;
     }
 
     .rs-small-list .rs-item .rs-content {
@@ -103,3 +137,12 @@
         margin-top: 10px;
     }
 }
+
+/* Global */
+
+.rs-content:after {
+    content: "";
+    display: table;
+    clear: both;
+}
+

--- a/programs-remote-listings/resources/frontend/rs.css
+++ b/programs-remote-listings/resources/frontend/rs.css
@@ -1,190 +1,105 @@
-/* clearfix */
-.rs-group:after { content: "."; display: block;  height: 0; clear: both; visibility: hidden; }
+/* Buttons and actions */
 
-.js .hide-if-js { display: none; }
-
-/* program display */
-.rs-program, .rs-teacher { margin-bottom: 25px;}
-.rs-teachers-container div.teacher { position: static !important;}
-.rs-program-list-intro { margin-bottom: 20px; }
-.rs-program-label { font-size: 85%; text-transform: uppercase; font-weight: bold; }
-/*.rs-program.important { border-top: 2px solid #ffd; padding-top: 8px; background-image: -webkit-linear-gradient(#ffd, #fff); background-image: -moz-linear-gradient(#ffe1bd, #fef9ef); }*/
-.rs-program.minor, .rs-programs-widget.minor { display: none; }
-.rs-program-thumbnail, .rs-teacher-thumbnail { float: left; margin-right: 15px; clear: left; margin-bottom: 5px;}
-.rs-program-title, .rs-program-teacher, .rs-teacher-title, .rs-program-with-teachers { line-height: 1.2; clear: none; }
-h2.rs-program-title { margin:0!important; }
-.rs-program-photo { margin-bottom: 20px; width:100%;}
-.rs-teacher-photo { float: left; margin-right: 20px; margin-bottom: 5px; }
-.rs-teacher-bio { clear: left; }
-.rs-program-with-teachers { margin:0 !important; padding:0 !important; }
-.single-program {
-    position: relative;
-}
-
-.single-program .entry-content {
-    float:left; width:100%;
-}
-.single-program .rs-program-meta {
-    width: 40%;
-    float: right;
-    box-sizing: border-box;
-    border-radius: 5px;
-    border: 1px solid #e5e5e5;
-    margin: 0 0 0 20px;
-}
-.rs-program-meta li { list-style: none; }
-/*.rs-program-meta { margin-bottom: 20px; margin-top: 10px; }*/
-
-.rs-meta-content-container { margin:20px 20px; }
-
-.rs-program-early-bird-discount {
-    font-weight: bold;
-}
-.single-program .rs-program-early-bird-discount {
-    border-width: 1px;
-    border-style: solid;;
-    /* color set dynamically based on theme highlight color */
-    background-color: #fff;
-    padding: 1.5rem;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-}
-
-/*registration link */
-.rs-regsitration-wrap { margin: 0 0 20px; /*white-space: nowrap; */}
-
-.rs-register-link a, #submit-registration, .rs-button {
-    /*height: 2em;*/
+.rs-register-link a, .rs-button {
+    display: inline-block;
+    text-decoration: none;
     font-weight: bold;
     padding: 12px 18px 10px;
-    /*color: #eb171c;*/
     font-size: 14px;
-    line-height: 100%;
-    text-decoration: none;
     text-transform: uppercase;
     cursor: pointer;
     border-radius: 5px;
-    /*background-color: #fff;*/
-    border: 1px solid #e5e5e5;;
-}
-.rs-register-link a:hover, #submit-registration:hover, .rs-big-button:hover, .rs-meta-content-container a.rs-button:hover {
-    border-color: #333;
+    border: 1px solid black !important;
+    color: black !important;
+    box-shadow: none !important;
+    transition: box-shadow 0.4s;
 }
 
-.rs-meta-content-container a.rs-button, .rs-meta-content-container .rs-register-link a {
-    width: 100%;
-    float: left;
-    margin:10px 0;
+.rs-register-link a:hover, .rs-button:hover {
+    text-decoration: none;
+    box-shadow: 0px 1px 1px rgba(50, 50, 50, 0.5) !important;
+}
+
+.rs-action {
+    margin: 10px 0;
+}
+
+/* Program Metabox */
+
+.rs-metabox {
+    width: 40%;
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin: 5px 10px 10px 10px;
+    border-radius: 5px;
+}
+
+.rs-metabox .rs-program-label {
+    margin-top: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    display: block;
+}
+
+.rs-metabox .rs-price ul {
+    margin: 0;
+    list-style: none;
+}
+
+.rs-metabox .rs-price .rs-program-label:after {
+    content: ":";
+}
+
+.rs-metabox .rs-action {
+    margin: 10px 0 0 0;
+}
+
+.rs-metabox .rs-action .rs-register-link a {
+    display: block;
     text-align: center;
-    box-sizing: border-box;
 }
 
-.rs-program-categories { clear: both; }
-
-/* registration form */
-#rs-registration-form { margin-bottom: 2em; }
-#rs-registration-form h2, .rs-form h2 { border-bottom: 1px dotted #CCC; padding: 0 0 5px 0; margin: 15px 0 5px; }
-
-#rs-registration-form .rs-error { color: #790000; font-weight: bold; font-size: 1.1em; padding: 15px; margin: 10px 0; }
-.wprs-registration-table, .rs-form { border-collapse: separate; border-spacing: 0 10px; border-width: 0; width: 100%; margin: 0; }
-.wprs-registration-table th, .rs-form th { color: #000; font-size: 1em; font-weight: normal; width: 40%; vertical-align: top; text-align: right; padding-right: 20px; }
-.wprs-registration-table td, .rs-form td { border-top-width: 0; }
-.wprs-registration-table td small, .rs-form td small { display: block; }
-/* registration form errors */
-#rs-registration-form .rs-custom-field-required { color: #790000; font-size: 1.2em; }
-#rs-registration-form .rs-custom-field-errors { color: #790000; font-size: 0.9em; font-weight: bold; margin: 5px 0; line-height: 1.3em; list-style-type: none; }
-#rs-registration-form .wprs-registration-error { background-color: #ffffdd; border: 1px dotted #790000; }
-#rs-registration-form .wprs-registration-error input, #content .wprs-registration-error select { border-color: #790000; }
-#rs-registration-form .wprs-registration-error label { color: #790000; }
-#rs-registration-form tr.wprs-registration-error th { border-width: 1px 0px 1px 1px; border-style: dotted; }
-#rs-registration-form tr.wprs-registration-error td { border-width: 1px 1px 1px 0px; border-style: dotted; }
-#rs-registration-form tr.wprs-registration-error td { border-top: 1px dotted #790000; }
-
-#rs-registration-form .rs-payment-error { color: #790000; background-color: #ffdfdf; border: 1px dotted #790000; padding: 10px; font-style: italic; font-weight: bold;}
-
-#rs-registration-form .rs-price { padding: 9px 0 0 30px; }
-#rs-registration-form .rs-price th { width: auto; }
-
-#rs-registration-form .rs-form-help, #rs-registration-form small, .rs-form small { font-size: 80%; color: #777; line-height: 1.4; }
-
-/*extra nights*/
-.rs-extra-nights, .rs-extra-nights a { float: right; }
-.rs-extra-nights div { float: right; clear: right; }
-
-/* registration total */
-.rs-total-calculated { font-size: 120%; }
-
-/* edit link */
-.rs-container .edit-link { float: right; font-size: 70%; text-transform: uppercase; }
-
-/* widgets */
-/*.rs-programs-widget { margin: 15px 0; list-style: none; clear: left; }*/
-.rs-programs-widget h4, .rs-programs-widget p { clear: none; line-height: 1.0; margin-bottom: 0px; }
-.rs-programs-widget ul { margin-left: 0 !important; }
-.rs-programs-widget ul li { clear: both; }
-
-
-.rs-custom-field-table th { width: 140px; }
-
-/* alerts - from twitter bootstrap */
-.alert { margin-bottom: 18px; text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5); background-color: #fcf8e3; border: 1px solid #fbeed5; -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px; padding: 8px 35px 8px 14px; }
-.alert-success { background-color: #dff0d8; border-color: #d6e9c6; }
-.alert-danger, .alert-error { background-color: #f2dede; border-color: #eed3d7; }
-.alert-info { background-color: #d9edf7; border-color: #bce8f1; }
-.alert-block { padding-top: 14px; padding-bottom: 14px; }
-.alert-block > p, .alert-block > ul { margin-bottom: 0; }
-.alert-block p + p { margin-top: 5px; }
-
-/* datepickers */
-.rs-stay-datepicker label { font-weight: bold; line-height: 40px;  }
-.rs-stay-datepicker input {  width: 100px; margin-left: 5px; }
-div.hasDatepicker { float: left; margin-right: 20px; }
-.ui-datepicker { width: 15em; }
-
-/* datepickers fixes for twenty ten */
-#content .ui-datepicker-calendar { margin: 0 0 0.4em; }
-#content .ui-datepicker tr td { padding: 0; }
-#content .ui-datepicker tr th { padding: 0; }
-
-.rs-program-additional-info { clear: left; }
-.rs-program-detail header h1 { font-size:200%; }
-
-.shortcode .rs-program-title { margin-bottom:2px; }
-
-.rs-register-link a { display: inline-block; }
-.shortcode .status div { display:inline; }
-.shortcode .status { width:150px;  }
-
-.rs-program.shortcode.table td, .rs-program.shortcode.table th { padding:5px; border-bottom: 1px solid #eaeaea; }
-.rs-program.shortcode.table tr:nth-child(even) {background: #f9f9f9 !important;}
-
-.rs-program.shortcode.table .rs-availability { text-align:center; }
-.rs-program.shortcode.table .rs-show-more-link { text-align:center; }
-.rs-program.shortcode.table .rs-show-register-link { text-align:center; }
-.rs-program.shortcode.table .rs-price ul { margin: 0; }
-
-/* responsive tables */
-@media (max-width:35em) {
-    .rs-program.table, .rs-program thead, .rs-program tbody, .rs-program tfoot, .rs-program th, .rs-program td, .rs-program tr { display:block; }
-    .rs-program.shortcode.table tr { margin-top:2em; margin-bottom: 2em; border-bottom: 1px solid #eaeaea; border-top: 1px solid #eaeaea; }
-    .rs-program.shortcode.table td, .rs-program.shortcode.table th { border-bottom: none; border-top: none; padding: 2px; text-align: center; }
+.rs-metabox .rs-photo {
+    width: 100%;
 }
 
-@media only screen and (max-width: 520px)
-{
-    .single-program .rs-program-meta { width:100% !important; }
-    .rs-program-title { padding:20px 0 0; }
+/* Small list */
+
+.rs-small-list .rs-item .rs-photo {
+    width: 150px;
 }
 
-/* teachers page responsive layout */
-@media only screen and (min-width: 375px) and (max-width: 575px) {
-    .rs-teacher-content img {
+.rs-small-list .rs-item .rs-content {
+    overflow: hidden;
+}
+
+.rs-small-list .rs-item .rs-item-title {
+    margin-top: 0;
+}
+
+/* Mobile overrides */
+
+@media screen and (max-width: 769px) {
+    .rs-metabox {
+        border: none;
+        padding: 0;
+        margin: 0 0 20px 0;
         width: 100%;
     }
-    .rs-teacher-custom-wrap {
-        clear: both;
+
+    .rs-single.rs-program > .rs-action {
+        display: none;
+    }
+
+    .rs-small-list .rs-item .rs-photo {
+        width: 100%;
+    }
+
+    .rs-small-list .rs-item .rs-content {
+        overflow: visible;
+    }
+
+    .rs-small-list .rs-item .rs-item-title {
+        margin-top: 10px;
     }
 }
-
-body.rs-programs-single h1.entry-title,
-body.rs-teachers-single h1.entry-title { display:none; }

--- a/programs-remote-listings/resources/frontend/rs.css
+++ b/programs-remote-listings/resources/frontend/rs.css
@@ -38,9 +38,9 @@
     float: right;
     width: 40%;
     border: 1px solid #ccc;
+    border-radius: 5px;
     padding: 10px;
     margin: 5px 10px 10px 10px;
-    border-radius: 5px;
 }
 
 .rs-metabox .rs-program-label {
@@ -72,7 +72,7 @@
     width: 100%;
 }
 
-/* Small list */
+/* List */
 
 .rs-list .rs-item .rs-item-title {
     margin-top: 0;
@@ -82,24 +82,38 @@
     margin-bottom: 2em;
 }
 
+.rs-list .rs-photo img {
+    width: 300px;
+}
+
+.rs-list .rs-item .rs-title {
+    margin-top: 0;
+}
+
 /* Teacher list */
 
 .rs-list.rs-teacher .rs-item .rs-photo {
-    width: 150px;
     float: left;
-    margin: 0 10px 0 0;
+    margin: 0 20px 0 0;
 }
 
 .rs-list.rs-teacher .rs-item .rs-content {
     overflow: hidden;
 }
 
+.rs-single.rs-program .rs-list.rs-teacher .rs-item .rs-photo {
+    width: 150px;
+}
+
 /* Program list */
 
 .rs-list.rs-program .rs-item .rs-photo {
-    width: 300px;
     float: right;
     margin: 0 0 0 20px;
+}
+
+.rs-list.rs-program .rs-item .rs-photo img {
+    width: 400px;
 }
 
 /* Mobile overrides */
@@ -113,12 +127,10 @@
         width: 100%;
     }
 
-    .rs-single .rs-photo,
-    .rs-list.rs-program .rs-item .rs-photo,
-    .rs-list.rs-teacher .rs-item .rs-photo {
-        width: 100%;
-        float: none;
-        margin: 20px 0;
+    .rs-photo {
+        width: 100% !important;
+        float: none !important;
+        margin: 20px 0 !important;
     }
 
     .rs-single.rs-program > .rs-action {
@@ -136,7 +148,8 @@
 
 /* Global */
 
-.rs-content:after {
+.rs-content:after,
+.rs-item:after {
     content: "";
     display: table;
     clear: both;
@@ -148,4 +161,18 @@
 
 .rs-location {
     font-weight: bold;
+}
+
+.rs-early-bird-discount {
+    border: 1px solid #000;
+    background-color: #fff;
+    padding: 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+.rs-registration-no-capacity {
+    margin-bottom: 10px;
+    font-weight: bold;
+    font-style: italic;
 }

--- a/programs-remote-listings/rs-connect.php
+++ b/programs-remote-listings/rs-connect.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: Retreat Booking Guru Connect
 Description: Connect to Retreat Booking Guru to show program listings on your site and link to registration forms.
-Version: 2.3.0
+Version: 3.0.0
 Author: Retreat Guru
 Author URI: http://retreat.guru/booking
 */
@@ -12,7 +12,7 @@ class RS_Connect
 {
     protected $options = null;
     protected $program = null;
-    public static $plugin_version = 'wp2.3.0'; // todo: always update this with wp + the plugin Version set above
+    public static $plugin_version = 'wp3.0.0'; // todo: always update this with wp + the plugin Version set above
 
     public function __construct()
     {

--- a/programs-remote-listings/rs-connect.php
+++ b/programs-remote-listings/rs-connect.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: Retreat Booking Guru Connect
 Description: Connect to Retreat Booking Guru to show program listings on your site and link to registration forms.
-Version: 2.2.3
+Version: 2.3.0
 Author: Retreat Guru
 Author URI: http://retreat.guru/booking
 */
@@ -12,7 +12,7 @@ class RS_Connect
 {
     protected $options = null;
     protected $program = null;
-    public static $plugin_version = 'wp2.2.3'; // todo: always update this with wp + the plugin Version set above
+    public static $plugin_version = 'wp2.3.0'; // todo: always update this with wp + the plugin Version set above
 
     public function __construct()
     {

--- a/programs-remote-listings/templates/shortcode-programs-single.php
+++ b/programs-remote-listings/templates/shortcode-programs-single.php
@@ -21,7 +21,7 @@ if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
 
     <div class="rs-action"><?php echo $rs_the_program->registration_action; ?></div>
 
-    <div class="rs-metabox alignright">
+    <div class="rs-metabox">
         <?php  if ($rs_the_program->photo_details) : ?>
             <div class="rs-photo">
                 <img src="<?php echo $rs_the_program->photo_details->large->url; ?>">
@@ -94,20 +94,19 @@ if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
             <?php foreach ($rs_the_program->teacher_details->teacher_objects as $teacher) : ?>
                 <?php $teacher_url = $RS_Connect->get_page_url('teachers') . $teacher->ID . '/' . $teacher->slug; ?>
                 <div class="rs-item">
-                    <h3 class="rs-item-title"><a href="<?php echo $teacher_url; ?>"><?php echo $teacher->name; ?></a></h3>
                     <?php if (isset($teacher->photo_details->medium)) { ?>
                         <div class="rs-photo">
                             <a href="<?php echo $teacher_url; ?>">
-                                <img class="alignleft" src="<?php echo $teacher->photo_details->medium->url; ?>">
+                                <img src="<?php echo $teacher->photo_details->medium->url; ?>">
                             </a>
                         </div>
                     <?php } ?>
                     <div class="rs-content">
+                        <h3 class="rs-item-title"><a href="<?php echo $teacher_url; ?>"><?php echo $teacher->name; ?></a></h3>
                         <div><?php echo $RS_Connect->excerpt($teacher->text); ?></div>
                         <div><a href="<?php echo $teacher_url; ?>">Learn more about <?php echo $teacher->name; ?></a></div>
                     </div>
                 </div>
-                <br/>
             <?php endforeach; ?>
         </div>
     <?php endif; ?>

--- a/programs-remote-listings/templates/shortcode-programs-single.php
+++ b/programs-remote-listings/templates/shortcode-programs-single.php
@@ -9,110 +9,109 @@ $options = get_option('rs_remote_settings');
 <?php
 if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
 
-<article class="single-program">
+<article class="rs-single rs-program">
 
-    <div class="entry-content">
+    <h2 class="rs-title"><?php echo $rs_the_program->title; ?></h2>
 
-        <div class="rs-program-meta">
-            <?php  if ($rs_the_program->photo_details) : ?>
-                <div class="rs-program-photo">
-                    <img src="<?php echo $rs_the_program->photo_details->large->url; ?>" width="100%">
-                </div>
-            <?php endif; ?>
+    <?php if (! empty($rs_the_program->teacher_list)) : ?>
+        <h3 class="rs-subtitle"><?php echo $rs_the_program->teacher_list; ?></h3>
+    <?php endif; ?>
 
-            <div class="rs-meta-content-container">
+    <p class="rs-date"><?php echo $rs_the_program->date; ?></p>
 
-                <?php if ($rs_the_program->early_bird_discount && empty($hide_discount)) : ?>
-                    <div class="rs-program-early-bird-discount rs-highlight"><?php echo $rs_the_program->early_bird_discount; ?></div>
-                <?php endif; ?>
+    <div class="rs-action"><?php echo $rs_the_program->registration_action; ?></div>
 
-                <?php // Pricing ?>
-                <?php if ($rs_the_program->price_details) : ?>
-                    <div class="rs-program-price"><?php echo $rs_the_program->price_details ?></div>
-                <?php endif; ?>
-
-                <?php // Datetime details ?>
-                <?php if ($rs_the_program->date_time) : ?>
-                    <p class="rs-program-datetime"><span class="rs-program-label">Date &amp; Time Details:</span> <?php echo $rs_the_program->date_time; ?></p>
-                <?php endif; ?>
-
-                <?php // Location ?>
-                <?php if ($rs_the_program->location) : ?>
-                    <p class="rs-program-location"><span class="rs-program-label">Location:</span> <?php echo $rs_the_program->location; ?></p>
-                <?php endif; ?>
-
-                <?php // Address ?>
-                <?php if ($rs_the_program->address) : ?>
-                    <p class="rs-program-address"><span class="rs-program-label">Address:</span> <?php echo $rs_the_program->address; ?></p>
-                <?php endif; ?>
-
-                <?php // Contact details ?>
-                <?php if ($rs_the_program->contact) : ?>
-                    <p class="rs-program-contact"><?php echo $rs_the_program->contact ?></p>
-                <?php endif; ?>
-
-                <?php // Custom fields ?>
-                <?php if ($rs_the_program->custom) : ?>
-                    <div class="rs-program-custom-wrap"><?php echo $rs_the_program->custom; ?></div>
-                <?php endif; ?>
-
-                <?php if ($rs_the_program->email && empty($options['rs_template']['hide_contact_button'])) : ?>
-                    <?php if (! empty($options['rs_template']['contact_button_text'])) {
-                        $contact_button_text = $options['rs_template']['contact_button_text'];
-                    } else {
-                        $contact_button_text = 'Email us about program';
-                    } ?>
-                    <a href="mailto:<?php echo $rs_the_program->email; ?>?subject=An inquiry about <?php echo $rs_the_program->title; ?>" class="rs-button"><?php echo $contact_button_text; ?></a>
-                <?php endif; ?>
-
-                <div class="rs-regsitration-wrap"><?php echo $rs_the_program->registration_action; ?></div>
-            </div>
-        </div>
-
-        <h1 class="rs-program-title"><?php echo $rs_the_program->title; ?></h1>
-        
-        <?php if (! empty($rs_the_program->teacher_list)) : ?>
-            <h2 class="rs-program-teacher"><?php echo $rs_the_program->teacher_list; ?></h2>
-        <?php endif; ?>
-        
-        <p class="rs-program-date"><?php echo $rs_the_program->date; ?></p>
-
-        <div class="rs-regsitration-wrap"><?php echo $rs_the_program->registration_action; ?></div>
-
-        <?php // Program Details ?>
-        <div class="rs-program-content">
-            <?php if ($rs_the_program->text_full) : ?>
-                <div class="rs-program-custom-wrap"><?php echo $rs_the_program->text_full; ?></div>
-            <?php endif; ?>
-        </div>
-
-        <?php if ($rs_the_program->teacher_details->teacher_objects) : ?>
-            <div class="rs-teachers-container">
-                <h2 class="rs-teachers-title"><?php echo _n('Teacher', 'Teachers',
-                        count($rs_the_program->teacher_details->teacher_objects)) ?></h2>
-
-                <?php foreach ($rs_the_program->teacher_details->teacher_objects as $teacher) : ?>
-                    <?php $teacher_url = $RS_Connect->get_page_url('teachers') . $teacher->ID . '/' . $teacher->slug; ?>
-                    <div class="teacher" style="clear:left; position:relative;">
-                        <?php if (isset($teacher->photo_details->medium)) { ?>
-                            <div
-                                style="float:left; width:<?php echo $teacher->photo_details->medium->width; ?>px; margin-right:20px;">
-                                <a href="<?php echo $teacher_url; ?>" style="float:left; margin:5px 20px 10px 0;">
-                                    <img src="<?php echo $teacher->photo_details->medium->url; ?>"
-                                         style="float:left; margin:5px 20px 10px 0;">
-                                </a>
-                            </div>
-                        <?php } ?>
-                        <div class="rs-teachers-content" style="overflow:hidden;">
-                            <a href="<?php echo $teacher_url; ?>"><strong><?php echo $teacher->name; ?></strong></a><br/>
-                            <?php echo $RS_Connect->excerpt($teacher->text); ?>
-                            <br/><a href="<?php echo $teacher_url; ?>">Learn more about <?php echo $teacher->name; ?></a>
-                        </div>
-                    </div>
-                <?php endforeach; ?>
+    <div class="rs-metabox alignright">
+        <?php  if ($rs_the_program->photo_details) : ?>
+            <div class="rs-photo">
+                <img src="<?php echo $rs_the_program->photo_details->large->url; ?>">
             </div>
         <?php endif; ?>
+
+        <div class="rs-metabox-details">
+
+            <?php if ($rs_the_program->early_bird_discount && empty($hide_discount)) : ?>
+                <div class="rs-early-bird-discount rs-highlight"><?php echo $rs_the_program->early_bird_discount; ?></div>
+            <?php endif; ?>
+
+            <?php // Pricing ?>
+            <?php if ($rs_the_program->price_details) : ?>
+                <div class="rs-price"><?php echo $rs_the_program->price_details ?></div>
+            <?php endif; ?>
+
+            <?php // Datetime details ?>
+            <?php if ($rs_the_program->date_time) : ?>
+                <div class="rs-datetime"><span class="rs-program-label">Date &amp; Time Details:</span> <?php echo $rs_the_program->date_time; ?></div>
+            <?php endif; ?>
+
+            <?php // Location ?>
+            <?php if ($rs_the_program->location) : ?>
+                <div class="rs-location"><span class="rs-program-label">Location:</span> <?php echo $rs_the_program->location; ?></div>
+            <?php endif; ?>
+
+            <?php // Address ?>
+            <?php if ($rs_the_program->address) : ?>
+                <div class="rs-address"><span class="rs-program-label">Address:</span> <?php echo $rs_the_program->address; ?></div>
+            <?php endif; ?>
+
+            <?php // Contact details ?>
+            <?php if ($rs_the_program->contact) : ?>
+                <div class="rs-contact"><?php echo $rs_the_program->contact ?></div>
+            <?php endif; ?>
+
+            <?php // Custom fields ?>
+            <?php if ($rs_the_program->custom) : ?>
+                <div class="rs-custom-fields"><?php echo $rs_the_program->custom; ?></div>
+            <?php endif; ?>
+
+            <?php if ($rs_the_program->email && empty($options['rs_template']['hide_contact_button'])) : ?>
+                <?php if (! empty($options['rs_template']['contact_button_text'])) {
+                    $contact_button_text = $options['rs_template']['contact_button_text'];
+                } else {
+                    $contact_button_text = 'Email us about program';
+                } ?>
+                <a href="mailto:<?php echo $rs_the_program->email; ?>?subject=An inquiry about <?php echo $rs_the_program->title; ?>" class="rs-button"><?php echo $contact_button_text; ?></a>
+            <?php endif; ?>
+
+            <div class="rs-action"><?php echo $rs_the_program->registration_action; ?></div>
+        </div>
     </div>
+
+    <?php // Program Content ?>
+    <?php if ($rs_the_program->text_full) : ?>
+    <div class="rs-content">
+        <?php echo $rs_the_program->text_full; ?>
+    </div>
+    <?php endif; ?>
+
+
+    <?php // Teachers ?>
+    <?php if ($rs_the_program->teacher_details->teacher_objects) : ?>
+        <div class="rs-small-list rs-teacher">
+            <h2 class="rs-title"><?php echo _n('Teacher', 'Teachers',
+                    count($rs_the_program->teacher_details->teacher_objects)) ?></h2>
+
+            <?php foreach ($rs_the_program->teacher_details->teacher_objects as $teacher) : ?>
+                <?php $teacher_url = $RS_Connect->get_page_url('teachers') . $teacher->ID . '/' . $teacher->slug; ?>
+                <div class="rs-item">
+                    <h3 class="rs-item-title"><a href="<?php echo $teacher_url; ?>"><?php echo $teacher->name; ?></a></h3>
+                    <?php if (isset($teacher->photo_details->medium)) { ?>
+                        <div class="rs-photo">
+                            <a href="<?php echo $teacher_url; ?>">
+                                <img class="alignleft" src="<?php echo $teacher->photo_details->medium->url; ?>">
+                            </a>
+                        </div>
+                    <?php } ?>
+                    <div class="rs-content">
+                        <div><?php echo $RS_Connect->excerpt($teacher->text); ?></div>
+                        <div><a href="<?php echo $teacher_url; ?>">Learn more about <?php echo $teacher->name; ?></a></div>
+                    </div>
+                </div>
+                <br/>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
     <div style="clear:both;"></div>
 
 </article>

--- a/programs-remote-listings/templates/shortcode-programs-single.php
+++ b/programs-remote-listings/templates/shortcode-programs-single.php
@@ -14,10 +14,10 @@ if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
     <h2 class="rs-title"><?php echo $rs_the_program->title; ?></h2>
 
     <?php if (! empty($rs_the_program->teacher_list)) : ?>
-        <h3 class="rs-subtitle"><?php echo $rs_the_program->teacher_list; ?></h3>
+        <h3 class="rs-with-teachers"><?php echo $rs_the_program->teacher_list; ?></h3>
     <?php endif; ?>
 
-    <p class="rs-date"><?php echo $rs_the_program->date; ?></p>
+    <div class="rs-date"><?php echo $rs_the_program->date; ?></div>
 
     <div class="rs-action"><?php echo $rs_the_program->registration_action; ?></div>
 

--- a/programs-remote-listings/templates/shortcode-programs-single.php
+++ b/programs-remote-listings/templates/shortcode-programs-single.php
@@ -41,7 +41,7 @@ if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
 
             <?php // Datetime details ?>
             <?php if ($rs_the_program->date_time) : ?>
-                <div class="rs-datetime"><span class="rs-program-label">Date &amp; Time Details:</span> <?php echo $rs_the_program->date_time; ?></div>
+                <div class="rs-date"><span class="rs-program-label">Date &amp; Time Details:</span> <?php echo $rs_the_program->date_time; ?></div>
             <?php endif; ?>
 
             <?php // Location ?>
@@ -87,7 +87,7 @@ if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
 
     <?php // Teachers ?>
     <?php if ($rs_the_program->teacher_details->teacher_objects) : ?>
-        <div class="rs-small-list rs-teacher">
+        <div class="rs-list rs-teacher">
             <h2 class="rs-title"><?php echo _n('Teacher', 'Teachers',
                     count($rs_the_program->teacher_details->teacher_objects)) ?></h2>
 
@@ -102,9 +102,9 @@ if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
                         </div>
                     <?php } ?>
                     <div class="rs-content">
-                        <h3 class="rs-item-title"><a href="<?php echo $teacher_url; ?>"><?php echo $teacher->name; ?></a></h3>
-                        <div><?php echo $RS_Connect->excerpt($teacher->text); ?></div>
-                        <div><a href="<?php echo $teacher_url; ?>">Learn more about <?php echo $teacher->name; ?></a></div>
+                        <h3 class="rs-title"><a href="<?php echo $teacher_url; ?>"><?php echo $teacher->name; ?></a></h3>
+                        <p><?php echo $RS_Connect->excerpt($teacher->text); ?></p>
+                        <p><a href="<?php echo $teacher_url; ?>">Learn more about <?php echo $teacher->name; ?></a></p>
                     </div>
                 </div>
             <?php endforeach; ?>

--- a/programs-remote-listings/templates/shortcode-programs.php
+++ b/programs-remote-listings/templates/shortcode-programs.php
@@ -13,7 +13,7 @@ if (is_array($shortcode_atts)) {
 
     <div class="rs-list rs-program">
     <?php foreach($rs_the_programs as $program): ?>
-        <?php $image_size = ! empty($options['rs_template']['image_size']) ? $options['rs_template']['image_size'] : 'large'; ?>
+        <?php $image_size = ! empty($options['rs_template']['image_size']) ? $options['rs_template']['image_size'] : 'medium'; ?>
         <?php $details_url = $program->alternate_url ? $program->alternate_url : $RS_Connect->get_page_url('programs').$program->ID.'/'.$program->slug; ?>
 
         <div class="rs-item <?php foreach($program->categories as $category) { echo 'rs-program-category-'.$category->slug . ' '; } ?>">
@@ -27,17 +27,17 @@ if (is_array($shortcode_atts)) {
 
             <p>
                 <?php if ($program->date && empty($hide_date)) : ?>
-            <div class="rs-date"><?php echo $program->date; ?></div>
-        <?php endif; ?>
+                    <div class="rs-date"><?php echo $program->date; ?></div>
+                <?php endif; ?>
 
-            <?php if ($program->location && empty($hide_location)) : ?>
-                <div class="rs-location"><?php echo $program->location; ?></div>
-            <?php endif; ?>
+                <?php if ($program->location && empty($hide_location)) : ?>
+                    <div class="rs-location"><?php echo $program->location; ?></div>
+                <?php endif; ?>
+
+                <?php if ($program->early_bird_discount && empty($hide_discount)) : ?>
+                    <div class="rs-early-bird-discount rs-highlight"><?php echo $program->early_bird_discount; ?></div>
+                <?php endif; ?>
             </p>
-
-            <?php if ($program->early_bird_discount && empty($hide_discount)) : ?>
-                <p class="rs-early-bird-discount rs-highlight"><?php echo $program->early_bird_discount; ?></p>
-            <?php endif; ?>
 
             <?php if ($program->photo_details && empty($hide_photo)) : ?>
                 <?php $program_image_url = $program->photo_details->{$image_size}->url; ?>

--- a/programs-remote-listings/templates/shortcode-programs.php
+++ b/programs-remote-listings/templates/shortcode-programs.php
@@ -7,51 +7,54 @@ $options = get_option('rs_remote_settings');
 if (is_array($shortcode_atts)) {
     extract($shortcode_atts);
 }
+?>
 
-if (! empty($rs_the_programs)) {
+<?php if (! empty($rs_the_programs)): ?>
 
-    foreach($rs_the_programs as $program):
-        $image_size = ! empty($options['rs_template']['image_size']) ? $options['rs_template']['image_size'] : 'medium';
-        $details_url = $program->alternate_url ? $program->alternate_url : $RS_Connect->get_page_url('programs').$program->ID.'/'.$program->slug; ?>
+    <div class="rs-list rs-program">
+    <?php foreach($rs_the_programs as $program): ?>
+        <?php $image_size = ! empty($options['rs_template']['image_size']) ? $options['rs_template']['image_size'] : 'large'; ?>
+        <?php $details_url = $program->alternate_url ? $program->alternate_url : $RS_Connect->get_page_url('programs').$program->ID.'/'.$program->slug; ?>
 
-        <?php // todo: the program categories should be appended with rs-program-category- ?>
-        <div class="rs-program rs-group <?php foreach($program->categories as $category) {echo $category->slug . " ";} ?>">
+        <div class="rs-item <?php foreach($program->categories as $category) { echo 'rs-program-category-'.$category->slug . ' '; } ?>">
+            <?php if ($program->title && empty($hide_title)) : ?>
+                <h2 class="rs-title"><a href="<?php echo $details_url; ?>"><?php echo $program->title; ?></a></h2>
+            <?php endif; ?>
+
+            <?php if ($program->teacher_list && empty($hide_with_teachers)) : ?>
+                <h3 class="rs-with-teachers"><?php echo $program->teacher_list; ?></h3>
+            <?php endif; ?>
+
+            <p>
+                <?php if ($program->date && empty($hide_date)) : ?>
+            <div class="rs-date"><?php echo $program->date; ?></div>
+        <?php endif; ?>
+
+            <?php if ($program->location && empty($hide_location)) : ?>
+                <div class="rs-location"><?php echo $program->location; ?></div>
+            <?php endif; ?>
+            </p>
+
+            <?php if ($program->early_bird_discount && empty($hide_discount)) : ?>
+                <p class="rs-early-bird-discount rs-highlight"><?php echo $program->early_bird_discount; ?></p>
+            <?php endif; ?>
+
             <?php if ($program->photo_details && empty($hide_photo)) : ?>
                 <?php $program_image_url = $program->photo_details->{$image_size}->url; ?>
-                <div class="rs-program-thumbnail"><a href="<?php echo $details_url; ?>"><img src="<?php echo $program_image_url; ?>"></a></div>
+                <div class="rs-photo"><a href="<?php echo $details_url; ?>"><img src="<?php echo $program_image_url; ?>"></a></div>
             <?php endif; ?>
 
             <?php if ($program->teacher_details->teacher_objects && ! empty($show_first_teacher_photo)) : ?>
                 <?php $teacher_image_url = $program->teacher_details->teacher_objects[0]->photo_details->{$image_size}->url; ?>
-                <div class="rs-teacher-thumbnail"><a href="<?php echo $details_url; ?>"><img src="<?php echo $teacher_image_url; ?>"></a></div>
-            <?php endif; ?>
-
-            <?php if ($program->title && empty($hide_title)) : ?>
-                <h3 class="rs-program-title"><a href="<?php echo $details_url; ?>"><?php echo $program->title; ?></a></h3>
-            <?php endif; ?>
-
-            <?php if ($program->teacher_list && empty($hide_with_teachers)) : ?>
-                <h3 class="rs-program-with-teachers"><?php echo $program->teacher_list; ?></h3>
-            <?php endif; ?>
-
-            <?php if ($program->date && empty($hide_date)) : ?>
-                <div class="rs-program-date"><?php echo $program->date; ?></div>
-            <?php endif; ?>
-
-            <?php if ($program->location && empty($hide_location)) : ?>
-                <div class="rs-program-location"><?php echo $program->location; ?></div>
-            <?php endif; ?>
-
-            <?php if ($program->early_bird_discount && empty($hide_discount)) : ?>
-                <div class="rs-program-early-bird-discount rs-highlight"><?php echo $program->early_bird_discount; ?></div>
+                <div class="rs-photo rs-teacher-thumbnail"><a href="<?php echo $details_url; ?>"><img src="<?php echo $teacher_image_url; ?>"></a></div>
             <?php endif; ?>
 
             <?php if ($program->text && empty($hide_text)) : ?>
-                <div class="rs-program-excerpt"><?php echo $RS_Connect->excerpt($program->text); ?></div>
+                <p class="rs-excerpt"><?php echo $RS_Connect->excerpt($program->text); ?></p>
             <?php endif; ?>
 
             <?php if ($program->price_first && ! empty($show_first_price)) : ?>
-                <div class="rs-program-first-price">From <?php echo $program->price_first; ?></div>
+                <p class="rs-first-price">From <?php echo $program->price_first; ?></p>
             <?php endif; ?>
 
             <?php if (! empty($show_register_link)) : ?>
@@ -68,8 +71,6 @@ if (! empty($rs_the_programs)) {
                 <?php endif; ?>
             <?php endif; ?>
         </div>
-
-    <?php endforeach;
-} else {
-    echo 'Sorry, no programs exist here.';
-}
+    <?php endforeach; ?>
+    </div>
+<?php endif; ?>

--- a/programs-remote-listings/templates/shortcode-teachers-single.php
+++ b/programs-remote-listings/templates/shortcode-teachers-single.php
@@ -9,22 +9,21 @@ $options = get_option('rs_remote_settings');
 if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
 
 <article class="page type-page status-publish entry hentry single-teacher">
-    <header class="entry-header">
-        <h1 class="rs-program-title"><?php echo $rs_the_teacher->name; ?></h1>
-    </header>
-
     <div class="entry-content">
+        <h1 class="rs-program-title"><?php echo $rs_the_teacher->name; ?></h1>
         <?php // Program Details ?>
-        <div class="rs-teacher-content" style="padding:20px;">
+        <div class="rs-teacher-content">
             <?php if (isset($rs_the_teacher->photo_details->medium)) : ?>
-                <img src="<?php echo $rs_the_teacher->photo_details->medium->url; ?>" class="alignleft" style="padding:0 20px 20px 0px; float: left;">
+                <div class="rs-teacher-photo">
+                    <img src="<?php echo $rs_the_teacher->photo_details->medium->url; ?>" class="alignleft">
+                </div>
             <?php endif; ?>
 
             <?php if ($rs_the_teacher->text_full) : ?>
                 <div class="rs-teacher-custom-wrap"><?php echo $rs_the_teacher->text_full; ?></div>
             <?php endif; ?>
         </div>
-        <div class="rs-teacher-programs" style="clear: left; margin:20px;">
+        <div class="rs-teacher-programs">
             <?php if (! empty($rs_the_teacher->programs)) : ?>
                 <h3 style="margin-top: 30px;">Events with <?php echo $rs_the_teacher->name; ?></h3>
 

--- a/programs-remote-listings/templates/shortcode-teachers-single.php
+++ b/programs-remote-listings/templates/shortcode-teachers-single.php
@@ -8,39 +8,44 @@ $options = get_option('rs_remote_settings');
 <?php
 if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
 
-<article class="page type-page status-publish entry hentry single-teacher">
-    <div class="entry-content">
-        <h1 class="rs-program-title"><?php echo $rs_the_teacher->name; ?></h1>
-        <?php // Program Details ?>
-        <div class="rs-teacher-content">
-            <?php if (isset($rs_the_teacher->photo_details->medium)) : ?>
-                <div class="rs-teacher-photo">
-                    <img src="<?php echo $rs_the_teacher->photo_details->medium->url; ?>" class="alignleft">
-                </div>
-            <?php endif; ?>
+<article class="rs-single rs-teacher">
 
-            <?php if ($rs_the_teacher->text_full) : ?>
-                <div class="rs-teacher-custom-wrap"><?php echo $rs_the_teacher->text_full; ?></div>
-            <?php endif; ?>
+    <h2 class="rs-title"><?php echo $rs_the_teacher->name; ?></h2>
+
+    <?php if (isset($rs_the_teacher->photo_details->large)) : ?>
+        <div class="rs-photo">
+            <img src="<?php echo $rs_the_teacher->photo_details->large->url; ?>">
         </div>
-        <div class="rs-teacher-programs">
-            <?php if (! empty($rs_the_teacher->programs)) : ?>
-                <h3 style="margin-top: 30px;">Events with <?php echo $rs_the_teacher->name; ?></h3>
+    <?php endif; ?>
 
-                <?php foreach($rs_the_teacher->programs as $program) : ?>
-                    <?php $program_url = $RS_Connect->get_page_url('programs').$program->ID.'/'.$program->slug; ?>
-                    <div class="program" style="float:left; clear:left;">
-                        <?php if(! empty($program->photo_details->thumbnail->url)) : ?>
-                        <a href="<?php echo $program_url; ?>"><img src="<?php echo $program->photo_details->thumbnail->url; ?>" style="float:left; margin:5px 15px 15px 0;"></a>
-                        <?php endif; ?>
-                        <strong><a href="<?php echo $program_url; ?>"><?php echo $program->title; ?></a></strong><br/>
-                        <?php echo date('F j, Y', $program->start); ?>
-                        <p><?php echo $RS_Connect->excerpt($program->text); ?></p>
+    <?php if ($rs_the_teacher->text_full) : ?>
+        <div class="rs-content">
+            <?php echo $rs_the_teacher->text_full; ?>
+        </div>
+    <?php endif; ?>
+
+    <div class="rs-small-list rs-program">
+        <?php if (! empty($rs_the_teacher->programs)) : ?>
+            <div></div>
+            <h2 class="rs-title">Events with <?php echo $rs_the_teacher->name; ?></h2>
+            <?php foreach($rs_the_teacher->programs as $program) : ?>
+                <?php $program_url = $RS_Connect->get_page_url('programs').$program->ID.'/'.$program->slug; ?>
+                <div class="rs-item">
+                    <h3 class="rs-item-title"><a href="<?php echo $program_url; ?>"><?php echo $program->title; ?></a></h3>
+                    <div class="rs-date"><?php echo date('F j, Y', $program->start); ?></div>
+                    <?php if(isset($program->photo_details->medium)) : ?>
+                        <div class="rs-photo">
+                            <a href="<?php echo $program_url; ?>">
+                                <img src="<?php echo $program->photo_details->medium->url; ?>">
+                            </a>
+                        </div>
+                    <?php endif; ?>
+                    <div class="rs-content">
+                        <div><?php echo $RS_Connect->excerpt($program->text); ?></div>
                     </div>
-                <?php endforeach; ?>
-            <?php endif; ?>
-        </div>
-        <div class="clearfix"></div>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
     </div>
 
 </article>

--- a/programs-remote-listings/templates/shortcode-teachers-single.php
+++ b/programs-remote-listings/templates/shortcode-teachers-single.php
@@ -24,7 +24,7 @@ if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
         </div>
     <?php endif; ?>
 
-    <div class="rs-small-list rs-program">
+    <div class="rs-list rs-program">
         <?php if (! empty($rs_the_teacher->programs)) : ?>
             <div></div>
             <h2 class="rs-title">Events with <?php echo $rs_the_teacher->name; ?></h2>

--- a/programs-remote-listings/templates/shortcode-teachers.php
+++ b/programs-remote-listings/templates/shortcode-teachers.php
@@ -4,16 +4,30 @@ global $rs_the_teachers;
 global $shortcode_atts;
 $options = get_option('rs_remote_settings');
 if (is_array($shortcode_atts)) extract($shortcode_atts);
-if (! empty($rs_the_teachers)) {
-    foreach ($rs_the_teachers as $teacher) :
-        $details_url = $RS_Connect->get_page_url('teachers').$teacher->ID.'/'.$teacher->slug; ?>
-        <div class="rs-teacher rs-group">
-            <div class="teacher type-teacher status-publish has-post-thumbnail hentry rs-teacher rs-group">
-                <?php if (isset($teacher->photo_details->thumbnail)) { ?>
-                    <div class="rs-teacher-thumbnail"><a href="<?php echo $details_url; ?>"><img width="150" height="150" src="<?php echo $teacher->photo_details->thumbnail->url; ?>" class="attachment-thumbnail wp-post-image" alt="DavidRome700" /></a></div>
-                <?php } ?>
-                <h2 class="rs-teacher-title"><a href="<?php echo $details_url; ?>"><?php echo $teacher->name; ?></a></h2>
-                <p class="rs-teacher-excerpt"><?php echo wp_trim_words($teacher->text, 100); ?></p>
-            </div>
+?>
+
+<?php if (! empty($rs_the_teachers)): ?>
+    <div class="rs-list rs-teacher">
+    <?php foreach($rs_the_teachers as $teacher): ?>
+        <?php $image_size = ! empty($options['rs_template']['image_size']) ? $options['rs_template']['image_size'] : 'medium'; ?>
+        <?php $details_url = $RS_Connect->get_page_url('teachers').$teacher->ID.'/'.$teacher->slug; ?>
+        <div class="rs-item">
+
+
+            <?php if (isset($teacher->photo_details->{$image_size})) : ?>
+                <div class="rs-photo">
+                    <img src="<?php echo $teacher->photo_details->{$image_size}->url; ?>">
+                </div>
+            <?php endif; ?>
+
+            <?php if ($teacher->text) : ?>
+                <div class="rs-content">
+                    <h2 class="rs-title"><a href="<?php echo $details_url; ?>"><?php echo $teacher->name; ?></a></h2>
+                    <div><?php echo $teacher->text; ?></div>
+                </div>
+            <?php endif; ?>
+
         </div>
-    <?php endforeach; } else { echo 'Sorry, no teachers exist here.'; } ?>
+    <?php endforeach; ?>
+    </div>
+<?php endif; ?>

--- a/programs-remote-tests/tests/acceptance/ShortcodesCest.php
+++ b/programs-remote-tests/tests/acceptance/ShortcodesCest.php
@@ -98,7 +98,7 @@ class ShortcodesCest
         $I->dontSee('Multi Person Lodging');
         $I->see('Example program');
         $I->see('Exhaustive program');
-        $I->click('Exhaustive program', '.rs-program-title');
+        $I->click('Exhaustive program', '.rs-title');
         $I->dontSee('Example program');
         $I->see('Register Now');
 


### PR DESCRIPTION
This PR is a full rework of the content rendering to make it work as well as possible within different themes. I used the minimal amount of styling I could get away with and reworked the CSS and HTML to use the same styles on all pages.

This is a breaking change for any site that customized the look of their lists,  but should make it easier to install the plugin going forward.

Since this is a breaking change, we might want to change the actual visual style of our pages and perhaps add support for big hero images.